### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,7 +6,7 @@ This is mostly meant to be used with snaps. Add the source as a part
 #+BEGIN_SRC yaml
 parts:
   sem-open-preload:
-    source: https://github.com/sergiusens/sem-open-preload
+    source: https://github.com/sergiusens/sem-open-preload.git
     plugin: make
 #+END_SRC
 


### PR DESCRIPTION
Fails to build without the .git, or source-type